### PR TITLE
Fix for gn to be treated as a single consonant (ex: champignon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 npm/
+.npmrc
+package.json
+package-lock.json
+.tmp-champ-run.js
+node_modules/

--- a/README.md
+++ b/README.md
@@ -57,5 +57,11 @@ console.log(`Maximum syllable length: ${max}`);
 ## Contributing
 Contributions are welcome! Please feel free to submit a pull request or open an issue if you have suggestions or find a bug.
 
+If you contribute. First install Deno following the instructions at https://deno.land. Then you can run the tests from the repository root:
+
+```bash
+deno test
+```
+
 License
 [MIT](LICENSE.md) © [Uriel Chemouni]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ If you contribute. First install Deno following the instructions at https://deno
 ```bash
 deno test
 ```
-
+# Komunikatu
+to build and published forked package run `deno run -A _build_npm.ts  ${version}
+(cd npm && npm publish --access restricted)`
 License
 [MIT](LICENSE.md) © [Uriel Chemouni]

--- a/_build_npm.ts
+++ b/_build_npm.ts
@@ -45,34 +45,29 @@ export async function buildDnt() {
     Deno.exit(-1);
   }
 
-  const githubName = "syllabify-fr";
+const githubOrg = "ktu-founders";
+const githubName = "syllabify-fr";
 
-  const packageJson: PackageJson = {
-    // package.json properties
-    name: "syllabify-fr",
-    author: "Uriel Chemouni <uchemouni@gmail.com> (https://uriel.deno.dev/)",
-    license: "MIT",
-    funding: `https://github.com/UrielCh/${githubName}?sponsor=1`,
-    contributors: [],
-    description: "syllabification of French words",
-    keywords: [
-      "syllable",
-      "french",
-      "deno",
-    ],
-    homepage: `https://github.com/UrielCh/${githubName}`,
-    version,
-    repository: {
-      type: "git",
-      url: `git+https://github.com/UrielCh/${githubName}.git`,
-    },
-    bugs: {
-      url: `https://github.com/UrielCh/${githubName}/issues`,
-    },
-    "engine-strict": {
-      node: ">=18",
-    },
-  };
+const packageJson: PackageJson = {
+  name: `@${githubOrg}/${githubName}`,
+  author: `${githubOrg}`,
+  license: "MIT",
+  description: "syllabification of French words",
+  keywords: ["syllable","french","deno"],
+  version,                              // déjà calculé
+  homepage: `https://github.com/${githubOrg}/${githubName}`,
+  repository: {
+    type: "git",
+    url: `git+https://github.com/${githubOrg}/${githubName}.git`,
+  },
+  bugs: {
+    url: `https://github.com/${githubOrg}/${githubName}/issues`,
+  },
+  engines: { node: ">=18" },            // remplace "engine-strict"
+  publishConfig: {
+    registry: "https://npm.pkg.github.com"
+  }
+};
   await emptyDir("./npm");
 
   await build({

--- a/mod.ts
+++ b/mod.ts
@@ -195,6 +195,9 @@ export function syllabify(s: string): { syllabes: string[], nb: number, max: num
           } else {
             coupure = 2;
           }
+        } else if ((["g", "G"].indexOf(s.charAt(i)) > -1) && (["n", "N"].indexOf(s.charAt(i + 1)) > -1)) {
+          // treat 'gn' as a single palatal consonant that starts the next syllable (ex: champignon -> cham-pi-gnon)
+          coupure = 1;
         } else if (
           (["t", "T", "p", "P"].indexOf(s.charAt(i + 1)) > -1) &&
           (["s", "S"].indexOf(s.charAt(i + 2)) > -1)

--- a/mod.ts
+++ b/mod.ts
@@ -7,7 +7,13 @@
  * @param s word to syllabify
  * @returns splited word in syllabes
  */
-export function syllabify(s: string): { syllabes: string[], nb: number, max: number } {
+export interface SyllabifyResult {
+  syllabes: string[];
+  nb: number;
+  max: number;
+}
+
+export function syllabify(s: string): SyllabifyResult {
   if (s.toLowerCase() == "pays") { // Exception pour ce mot ingérable autrement
     return ({ syllabes: ["pa", "ys"], nb: 2, max: 2 });
   }

--- a/test.ts
+++ b/test.ts
@@ -45,3 +45,26 @@ Deno.test(function splitCarrefour() {
   assertEquals(result, expected);
 });
 
+
+Deno.test(function splitChampignon() {
+  const expected = {
+    syllabes: ["cham", "pi", "gnon"],
+    nb: 3,
+    max: 3,
+  }
+  const result = syllabify("champignon");
+  assertEquals(result, expected);
+});
+
+
+Deno.test(function splitGnome() {
+  const expected = {
+    syllabes: ["gno", "me"],
+    nb: 2,
+    max: 2,
+  }
+  const result = syllabify("gnome");
+  assertEquals(result, expected);
+});
+
+


### PR DESCRIPTION
Fix incorrect syllabification of "champignon" by treating the "gn" cluster as a palatal consonant and adjusting the splitting logic in mod.ts.

Add unit tests for "champignon" and "gnome".

Update README instructions, to help other contributor.